### PR TITLE
Use `ElementHelper::generateSlug` instead of `StringHelper::slugify`

### DIFF
--- a/src/SlugEqualsTitle.php
+++ b/src/SlugEqualsTitle.php
@@ -9,7 +9,7 @@ use craft\commerce\elements\Product;
 use craft\commerce\services\ProductTypes;
 use craft\elements\Category;
 use craft\elements\Entry;
-use craft\helpers\StringHelper;
+use craft\helpers\ElementHelper;
 use craft\web\View;
 use internetztube\slugEqualsTitle\assetBundles\ExcludeFromRewriteAssetBundle;
 use internetztube\slugEqualsTitle\services\ElementStatusService;
@@ -41,13 +41,7 @@ class SlugEqualsTitle extends Plugin
             }
             if (!$toOverwrite) return;
 
-            $slug = $element->title;
-            if (Craft::$app->getConfig()->getGeneral()->limitAutoSlugsToAscii) {
-                $slug = StringHelper::toAscii($slug, $element->site->language);
-            }
-            $slug = StringHelper::slugify($slug, '-', $element->site->language);
-
-            $element->slug = $slug;
+            $element->slug = ElementHelper::generateSlug($element->title, null, $element->site->language);
         };
 
         $afterSafeCallback = function(Event $event) {


### PR DESCRIPTION
Is there a reason you're using `StringHelper::slugify` instead of `ElementHelper::generateSlug`?

I wanted to quickly and easily reset a bunch of entries whose slugs had gotten out of wack with this plugin. But there's been a lot of inconsistencies with the slug's generated by this plugin, which don't match Craft's native slug-generation.

For example, Craft will turn `Import/Export` to `import-export`, while this plugin will result in `importexport`. 

Rather than re-invent the wheel, it might be easier and more consistent to use the same function Craft uses to generate slugs for entries when they are new. In fact, it also takes care of `limitAutoSlugsToAscii` which you're doing yourself.

This is also targeted at the Craft 3 version for now.