### PR TITLE
Update ElementStatusService.php

### DIFF
--- a/src/services/ElementStatusService.php
+++ b/src/services/ElementStatusService.php
@@ -76,6 +76,10 @@ class ElementStatusService extends Component
         $enabledTypeHandles = SlugEqualsTitle::$plugin->getSettings()->{$mapping['settingName']};
         $elementType = $mapping['typeFromElement']($element);
 
+        if (!$elementType || !property_exists($elementType, 'handle')) {
+            return false;
+        }
+
         foreach ($enabledTypeHandles as $enabledTypeHandle) {
             if ($enabledTypeHandle === $elementType->handle) return true;
         }


### PR DESCRIPTION
Adds an extra check to quick-fix the plugin breaking:
- entries in Matrix fields when the layout is set to anything other than inline-editing
- entries in CKEditor fields